### PR TITLE
"buying things" proposal

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 # Maintenance
 
+- [Buying Things](buying_things.md)
 - [Garage Doors](garage_doors.md)
 - [Electrical](electrical.md)
 - [Air Compressor](air_compressor.md)

--- a/src/buying_things.md
+++ b/src/buying_things.md
@@ -7,10 +7,11 @@ Part of this is restocking maintenance supplies.
 
 You can buy anything on the [Shopping
 List](https://docs.google.com/spreadsheets/d/17nph-7mVd-YzlKXFxk2uTholVokZJ7OVb105P4w_eaY/edit?usp=sharing)
-and expect to be reimbursed. Unless otherwise noted on the shopping list, don't
-accrue more than $50 of shopping without getting specific approval from a board
-member. If something is not on the list, email a proposal to amend the list for
-the next member meeting.
+and expect to be reimbursed. You can propose changes to the list at the next
+member meeting. Unless otherwise noted on the shopping list, don't accrue more
+than $50 of shopping without getting specific approval from a board member. Do
+note that the treasurer reserves the right to veto any reimbursement in cases
+of abuse.
 
 After making your purchase, immediately email a reimbursement request to
 <altspace-finance@googlegroups.com>.

--- a/src/buying_things.md
+++ b/src/buying_things.md
@@ -5,10 +5,12 @@ Part of this is restocking maintenance supplies.
 
 ## You can make small purchases to keep the space running smoothly
 
-If the space needs something small and uncontroversial to stay nice, e.g.
-toilet paper or trash bags, any member is empowered to spend up to $50 on such
-things, and can expect to be reimbursed in a timely manner. Don't accrue more
-than $50 of expenses before being reimbursed.
+You can buy anything on the [Shopping
+List](https://docs.google.com/spreadsheets/d/17nph-7mVd-YzlKXFxk2uTholVokZJ7OVb105P4w_eaY/edit?usp=sharing)
+and expect to be reimbursed. Unless otherwise noted on the shopping list, don't
+accrue more than $50 of shopping without getting specific approval from a board
+member. If something is not on the list, email a proposal to amend the list for
+the next member meeting.
 
 After making your purchase, immediately email a reimbursement request to
 <altspace-finance@googlegroups.com>.

--- a/src/buying_things.md
+++ b/src/buying_things.md
@@ -1,0 +1,75 @@
+# Buying Things
+
+All alt space members are expected to leave the space nicer than they found it.
+Part of this is restocking maintenance supplies.
+
+## You can make small purchases to keep the space running smoothly
+
+If the space needs something small and uncontroversial to stay nice, e.g.
+toilet paper or trash bags, any member is empowered to spend up to $50 on such
+things, and can expect to be reimbursed in a timely manner. Don't accrue more
+than $50 of expenses before being reimbursed.
+
+After making your purchase, immediately email a reimbursement request to
+<altspace-finance@googlegroups.com>.
+
+It should include:
+
+- what you bought
+- how much it cost
+- a photo of the receipt
+- reimbursement method: either paypal or pick up a check from the space
+
+**example**
+
+    To: altspace-finance@googlegroups.com
+    Subject: Reimbursement request: $8.40 for toilet paper
+
+    Body:
+    I bought $8.40 worth of toilet paper for the main space today.
+    My paypal is: my-email@mydomain.com
+
+    Attached: receipt.jpg
+
+The treasurer will be responsible for processing reimbursements in a timely
+manner, at least monthly.
+
+## Board members can make larger discretionary purchases
+
+Board members have more responsibilities for maintaining the space.
+Consequently, they have larger discretionary purchasing power. In line with the
+proposed by-laws, a board member can spend up to $500 on the space, provided at
+least one other board member is informed.
+
+If you are not a board member, and would like to make a larger-than-$50
+reimbursable purchase, you must first either get the written approval of a
+board member or bring a proposal to the next member meeting.
+
+## For anything non-trivial
+
+For trivial things like restocking toilet paper, just buy it. However for many
+tools and replacement parts, other folks often have useful experience to inform
+your purchase. If there's any reasonable doubt, even if you are a board member,
+communicate on discord or the mailing list first. For more substantial
+purchases, bring a proposal to the member meeting.
+
+**example**
+
+    To: altspace-seattle@googlegroups.com
+    Subject: Purchase request: about $90.00 to fix the table saw
+
+    Body:
+
+    We need a new motor for the table saw cuz the old one burned out.
+
+    I researched replacements and found this to be a good one, for about $70 +
+    shipping: https://motors.com/really-good-deal/item-1337.html.
+
+    It should be about $90 with shipping.
+
+    Can I get reimbursement approval from a board member to buy this?
+
+
+After any discussion, once you get approval, make the purchase and send your
+approved reimbursement request to <altspace-finance@googlegroups.com>.
+


### PR DESCRIPTION
Meeting minutes are still forthcoming, but... the "buying things" proposal was amended. Notably, we added an explicit veto clause in cases where the treasurer suspects abuse.

It was approved at the members meeting, with one vote being *conditional* that the current treasurer is on board. In particular, one member wanted to make sure that you (@kryptographik) felt it was on solid ground WRT financial/corporate status.

My hot take is is:
1. It's fine/legal for _anyone_ to spend the spaces money maintaining the space in pursuit of the mission.

2. The trick is when/if someone (hypothetically) spends money *not* in pursuit of the mission. There's always going to be a non-zero risk that someone *could* game AltSpace for funds. That was certainly possible before - e.g. if I lied about something I spent money on, you'd still probably reimburse me unless the lie was bad or the amount of money was exorbitant. Does this new system qualitatively change that? I don't think so. 🤷 