### PR TITLE
Remove Plasma Cutter Documentation

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,7 +8,6 @@
 
 - [Laser Engravers](laser_engravers.md)
 - [Lobo CNC Mill](./Lobo_CNC/Lobo_CNC_Mill.md)
-- [Torchmate Plasma Table](./Torchmate/Torchmate_Plasma_Table.md)
 
 # Maintenance
 

--- a/src/Torchmate/Torchmate_Plasma_Table.md
+++ b/src/Torchmate/Torchmate_Plasma_Table.md
@@ -1,7 +1,0 @@
-# Torchmate Plasma Cutting Table
-
-TBD
-
-Working Notes: https://docs.google.com/document/d/1qeKu010Aiu2q-D895r8eaPH7ZCR6tQUISDu4nlC6EyE/edit?usp=sharing 
-
-

--- a/src/fire_permit.md
+++ b/src/fire_permit.md
@@ -1,6 +1,6 @@
 # 🔥Fire Permit and Extinguishers🧯
 
-Some of our tools, like welding equipment and the plasma cutter, require us to
+Some of our tools, like welding equipment, require us to
 have an up to date fire permit - it's a piece of paper hanging in the metal
 shop, that must be renewed annually.
 


### PR DESCRIPTION
AltSpace no longer has the Torchmate Plasma cutter as such removing the documentation pages for it.